### PR TITLE
Display Username on delete card action in activity window

### DIFF
--- a/client/src/components/Card.js
+++ b/client/src/components/Card.js
@@ -33,7 +33,7 @@ export default function Card({ task, index }) {
     const [card, setCard] = useState(true)
     const [showDelete, setShowDelete] = useState(false)
     const classes = useStyles()
-    const { token } = useSelector(state => state.user)
+    const { token, user } = useSelector(state => state.user)
     const dispatch = useDispatch()
     return (
         <Draggable draggableId={task._id} index={index}>
@@ -87,7 +87,7 @@ export default function Card({ task, index }) {
                                     onClick={() => {
                                         setCard(false)
                                         dispatch(deleteCardById(task._id))
-                                        const text = `User deleted card ${task.name}`
+                                        const text = `${user.username} deleted card ${task.name}`
                                         dispatch(createNewActivity({ text, boardId: task.boardId }, token))
                                     }}
                                 >


### PR DESCRIPTION
### Overview Description

# Issue Reference: #11

# Changes
Replace static "User" string with username

# Expected Outcome
Username is displayed in the activity log of the board
![image](https://user-images.githubusercontent.com/5517677/95429514-cad33000-094a-11eb-811a-f90d1642d8c6.png)

# Additional Information

Closes #11

Side note: Do you have any commit message guidelines?