### PR TITLE
Allow enter key to add new boards, lists, and cards

### DIFF
--- a/client/src/components/Board.js
+++ b/client/src/components/Board.js
@@ -291,6 +291,13 @@ export default function Board() {
         setListTitle('')
     }
 
+    const handleKeyDown = (e) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            submitHandler();
+        }
+    }
+
     const closeButtonHandler = () => {
         setAddListFlag(false)
         addFlag.current = true
@@ -400,6 +407,7 @@ export default function Board() {
                                                 changedHandler={handleChange}
                                                 itemAdded={submitHandler}
                                                 closeHandler={closeButtonHandler}
+                                                keyDownHandler={handleKeyDown}
                                                 type='list'
                                                 btnText='Add List'
                                                 placeholder='Enter list title...'

--- a/client/src/components/Boards.js
+++ b/client/src/components/Boards.js
@@ -93,6 +93,13 @@ export default function Boards() {
         setBoardTitle(e.target.value)
     }
 
+    const handleKeyDown = (e) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            submitHandler();
+        }
+    }
+
     useEffect(() => {
         if (newBoard) {
             dispatch(createNewActivity({
@@ -177,6 +184,7 @@ export default function Boards() {
                                             fullWidth
                                             value={boardTitle}
                                             onChange={handleChange}
+                                            onKeyDown={handleKeyDown}
                                             onBlur={() => {
                                                 submitHandler()
                                                 setShowInput(false)

--- a/client/src/components/InputCard.js
+++ b/client/src/components/InputCard.js
@@ -39,7 +39,7 @@ const useStyles = makeStyles((theme) => ({
     })
 }))
 
-export default function InputItem({ value, changedHandler, itemAdded, closeHandler, width, type, btnText, placeholder, marginLeft }) {
+export default function InputItem({ value, changedHandler, keyDownHandler, itemAdded, closeHandler, width, type, btnText, placeholder, marginLeft }) {
     const classes = useStyles({ type, width, marginLeft })
     const divRef = useRef(null)
 
@@ -62,7 +62,8 @@ export default function InputItem({ value, changedHandler, itemAdded, closeHandl
                     value={value}
                     autoFocus
                     placeholder={placeholder}
-                    onBlur={handleBlur} />
+                    onBlur={handleBlur} 
+                    onKeyDown={keyDownHandler} />
             </Paper>
             <Button
                 ref={divRef}

--- a/client/src/components/List.js
+++ b/client/src/components/List.js
@@ -105,6 +105,12 @@ export default function Column({ column, tasks, index }) {
         e.preventDefault()
         setListTitle(e.target.value)
     }
+    const handleKeyDown = (e) => {
+        if (e.key === "Enter") {
+            e.preventDefault();
+            submitHandler();
+        }
+    }
     const updateListTitle = () => {
         const text = listTitle.trim().replace(/\s+/g, ' ')
         if (text === '') {
@@ -185,6 +191,7 @@ export default function Column({ column, tasks, index }) {
                                                     changedHandler={handleChange}
                                                     itemAdded={submitHandler}
                                                     closeHandler={closeButtonHandler}
+                                                    keyDownHandler={handleKeyDown}
                                                     type='card'
                                                     btnText='Add Card'
                                                     placeholder='Enter a title for this card...'


### PR DESCRIPTION
**Description**

keyDown handlers are added that check for the "Enter" key being pressed when editing boards, lists, or cards. If "Enter" is pressed, then the board, list, or card is created immediately, instead of the user having to press the button with the mouse.

**Contribution Guidelines** Please read through the [Contribution Guidelines](https://github.com/ayushagg31/Trellis/blob/master/CONTRIBUTING.md)

**Fixes** # (issue reference)
Fixes #46

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Expected Outcome**

**Additional Information**

