### PR TITLE
feat(activites): add pagination to activity list

### DIFF
--- a/api/boardHandler.js
+++ b/api/boardHandler.js
@@ -74,11 +74,14 @@ router.get('/:id/cards', auth, async (req, res, next) => {
 // get activities based on boardId
 router.get('/:id/activities', auth, async (req, res, next) => {
     const _id = req.params.id
+    const _skip = Number.parseInt(req.query.skip, 10) || 0
+    const _limit = Number.parseInt(req.query.limit, 10) || 10
     try {
         const board = await Board.findOne({ _id, userId: req.user })
         if (!board)
             return res.status(404).send()
-        const activities = await Activity.find({ boardId: _id })
+        const activities = await Activity.find({ boardId: _id }, null, { skip: _skip, limit: _limit, sort: { createdAt: 'desc' } })
+        res.append('X-Total-Count', await Activity.countDocuments({ boardId: _id }))
         res.send(activities)
     } catch (error) {
         next(error)

--- a/api/boardHandler.js
+++ b/api/boardHandler.js
@@ -83,9 +83,9 @@ router.get('/:id/activities', auth, async (req, res, next) => {
         const query = { boardId: _id }
         if (_last)
             query._id = {'$lt': _last}
-        const activities = await Activity.find(query, null, { limit: _limit, sort: { _id: 'desc' } })
-        res.append('X-Total-Count', await Activity.countDocuments({ boardId: _id }))
-        res.send(activities)
+        const activities = await Activity.find(query, null, { limit: _limit + 1, sort: { _id: 'desc' } })
+        res.append('X-Has-More', activities.length === _limit + 1 ? 'true' : 'false')
+        res.send(activities.slice(0, _limit))
     } catch (error) {
         next(error)
     }

--- a/api/boardHandler.js
+++ b/api/boardHandler.js
@@ -74,13 +74,16 @@ router.get('/:id/cards', auth, async (req, res, next) => {
 // get activities based on boardId
 router.get('/:id/activities', auth, async (req, res, next) => {
     const _id = req.params.id
-    const _skip = Number.parseInt(req.query.skip, 10) || 0
+    const _last = req.query.last
     const _limit = Number.parseInt(req.query.limit, 10) || 10
     try {
         const board = await Board.findOne({ _id, userId: req.user })
         if (!board)
             return res.status(404).send()
-        const activities = await Activity.find({ boardId: _id }, null, { skip: _skip, limit: _limit, sort: { createdAt: 'desc' } })
+        const query = { boardId: _id }
+        if (_last)
+            query._id = {'$lt': _last}
+        const activities = await Activity.find(query, null, { limit: _limit, sort: { _id: 'desc' } })
         res.append('X-Total-Count', await Activity.countDocuments({ boardId: _id }))
         res.send(activities)
     } catch (error) {

--- a/client/src/actions/actionCreators/boardActions.js
+++ b/client/src/actions/actionCreators/boardActions.js
@@ -106,13 +106,9 @@ export const fetchsCardsFromBoard = (id, token) => (dispatch) => {
     })
 }
 
-export const fetchActivitiesFromBoard = (
-  id,
-  token,
-  additional,
-  last,
-  limit,
-) => (dispatch) => {
+export const fetchActivitiesFromBoard = (id, token, last, limit) => (
+  dispatch,
+) => {
   let params = ''
   if (last) params += `&last=${last}`
   if (limit) params += `&limit=${limit || 10}`
@@ -126,7 +122,7 @@ export const fetchActivitiesFromBoard = (
         payload: {
           activities: res.data,
           activityCount: parseInt(res.headers['x-total-count'], 10) || 1,
-          additional,
+          add: !!last,
         },
       })
     })

--- a/client/src/actions/actionCreators/boardActions.js
+++ b/client/src/actions/actionCreators/boardActions.js
@@ -106,15 +106,20 @@ export const fetchsCardsFromBoard = (id, token) => (dispatch) => {
     })
 }
 
-export const fetchActivitiesFromBoard = (id, token) => (dispatch) => {
+export const fetchActivitiesFromBoard = (id, token, skip, limit) => (
+  dispatch,
+) => {
   axios
-    .get(`${BASE_URL + id}/activities`, {
+    .get(`${BASE_URL + id}/activities?skip=${skip || 0}&limit=${limit || 10}`, {
       headers: { 'x-auth-token': token },
     })
     .then((res) => {
       dispatch({
         type: ACTIONS.GET_ACTIVITIES,
-        payload: { activities: res.data },
+        payload: {
+          activities: res.data,
+          activityCount: parseInt(res.headers['x-total-count'], 10) || 1,
+        },
       })
     })
     .catch((e) => {

--- a/client/src/actions/actionCreators/boardActions.js
+++ b/client/src/actions/actionCreators/boardActions.js
@@ -106,11 +106,18 @@ export const fetchsCardsFromBoard = (id, token) => (dispatch) => {
     })
 }
 
-export const fetchActivitiesFromBoard = (id, token, skip, limit) => (
-  dispatch,
-) => {
+export const fetchActivitiesFromBoard = (
+  id,
+  token,
+  additional,
+  last,
+  limit,
+) => (dispatch) => {
+  let params = ''
+  if (last) params += `&last=${last}`
+  if (limit) params += `&limit=${limit || 10}`
   axios
-    .get(`${BASE_URL + id}/activities?skip=${skip || 0}&limit=${limit || 10}`, {
+    .get(`${BASE_URL + id}/activities?${params}`, {
       headers: { 'x-auth-token': token },
     })
     .then((res) => {
@@ -119,6 +126,7 @@ export const fetchActivitiesFromBoard = (id, token, skip, limit) => (
         payload: {
           activities: res.data,
           activityCount: parseInt(res.headers['x-total-count'], 10) || 1,
+          additional,
         },
       })
     })

--- a/client/src/actions/actionCreators/boardActions.js
+++ b/client/src/actions/actionCreators/boardActions.js
@@ -121,7 +121,7 @@ export const fetchActivitiesFromBoard = (id, token, last, limit) => (
         type: ACTIONS.GET_ACTIVITIES,
         payload: {
           activities: res.data,
-          activityCount: parseInt(res.headers['x-total-count'], 10) || 1,
+          hasMore: res.headers['x-has-more'] === 'true',
           add: !!last,
         },
       })

--- a/client/src/components/Activities.js
+++ b/client/src/components/Activities.js
@@ -1,7 +1,9 @@
 import React, { useEffect, useState } from 'react'
 import moment from 'moment'
-import { useSelector } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import { makeStyles } from '@material-ui/core'
+import AddItem from './AddItem'
+import { fetchActivitiesFromBoard } from '../actions/actionCreators/boardActions'
 const useStyles = makeStyles((theme) => ({
   wrapper: {
     fontFamily: 'Arial, Helvetica, sans-serif',
@@ -19,11 +21,14 @@ const useStyles = makeStyles((theme) => ({
   },
 }))
 
-export default function Activities() {
+export default function Activities({ board }) {
   const classes = useStyles()
   // eslint-disable-next-line
   const [dt, setDt] = useState(new Date().toLocaleString())
-  const { activities } = useSelector((state) => state.activities)
+  const { activities, activityCount } = useSelector((state) => state.activities)
+  const dispatch = useDispatch()
+  const { token } = useSelector((state) => state.user)
+  const [page, setPage] = useState(0)
 
   useEffect(() => {
     const secTimer = setInterval(() => {
@@ -32,10 +37,16 @@ export default function Activities() {
     return () => clearInterval(secTimer)
   }, [])
 
+  const loadMoreActivities = () => {
+    const currentPage = page + 1
+    const skip = currentPage * 10
+    dispatch(fetchActivitiesFromBoard(board.id, token, skip, 10))
+    setPage(currentPage)
+  }
+
   return (
     <div className={classes.wrapper}>
-      {activities.map((intialActivity, index) => {
-        const activity = activities[activities.length - 1 - index]
+      {activities.map((activity) => {
         const date = new Date(activity.createdAt)
         const str = moment(date).fromNow()
         /* eslint-disable-next-line  */
@@ -74,6 +85,14 @@ export default function Activities() {
           </div>
         )
       })}
+      {(page + 1) * 10 < activityCount && (
+        <AddItem
+          btnText="Load more"
+          handleClick={() => loadMoreActivities()}
+          type="background"
+          width="310px"
+        />
+      )}
     </div>
   )
 }

--- a/client/src/components/Activities.js
+++ b/client/src/components/Activities.js
@@ -28,7 +28,6 @@ export default function Activities({ board }) {
   const { activities, activityCount } = useSelector((state) => state.activities)
   const dispatch = useDispatch()
   const { token } = useSelector((state) => state.user)
-  const [page, setPage] = useState(0)
 
   useEffect(() => {
     const secTimer = setInterval(() => {
@@ -38,10 +37,10 @@ export default function Activities({ board }) {
   }, [])
 
   const loadMoreActivities = () => {
-    const currentPage = page + 1
-    const skip = currentPage * 10
-    dispatch(fetchActivitiesFromBoard(board.id, token, skip, 10))
-    setPage(currentPage)
+    const lastActivity = activities[activities.length - 1]
+    dispatch(
+      fetchActivitiesFromBoard(board.id, token, true, lastActivity._id, 10),
+    )
   }
 
   return (
@@ -85,7 +84,7 @@ export default function Activities({ board }) {
           </div>
         )
       })}
-      {(page + 1) * 10 < activityCount && (
+      {activities.length < activityCount && (
         <AddItem
           btnText="Load more"
           handleClick={() => loadMoreActivities()}

--- a/client/src/components/Activities.js
+++ b/client/src/components/Activities.js
@@ -25,7 +25,7 @@ export default function Activities({ board }) {
   const classes = useStyles()
   // eslint-disable-next-line
   const [dt, setDt] = useState(new Date().toLocaleString())
-  const { activities, activityCount } = useSelector((state) => state.activities)
+  const { activities, hasMore } = useSelector((state) => state.activities)
   const dispatch = useDispatch()
   const { token } = useSelector((state) => state.user)
 
@@ -82,7 +82,7 @@ export default function Activities({ board }) {
           </div>
         )
       })}
-      {activities.length < activityCount && (
+      {hasMore && (
         <AddItem
           btnText="Load more"
           handleClick={() => loadMoreActivities()}

--- a/client/src/components/Activities.js
+++ b/client/src/components/Activities.js
@@ -38,9 +38,7 @@ export default function Activities({ board }) {
 
   const loadMoreActivities = () => {
     const lastActivity = activities[activities.length - 1]
-    dispatch(
-      fetchActivitiesFromBoard(board.id, token, true, lastActivity._id, 10),
-    )
+    dispatch(fetchActivitiesFromBoard(board.id, token, lastActivity._id, 10))
   }
 
   return (

--- a/client/src/components/SideMenu.js
+++ b/client/src/components/SideMenu.js
@@ -114,7 +114,7 @@ export default function SideMenu({ setBackground, board }) {
             </div>
           </div>
           <div className={classes.scroll}>
-            <Activities />
+            <Activities board={{ id: board.id }} />
           </div>
         </Paper>
       )}

--- a/client/src/reducers/activityReducer.js
+++ b/client/src/reducers/activityReducer.js
@@ -8,13 +8,16 @@ export const activityReducer = (state = initialState, action) => {
     case ACTIONS.GET_ACTIVITIES:
       return {
         ...state,
-        activities: [...state.activities, ...action.payload.activities],
+        activities: [
+          ...(action.payload.additional ? state.activities : []),
+          ...action.payload.activities,
+        ],
         activityCount: action.payload.activityCount,
       }
     case ACTIONS.ADD_ACTIVITY:
       return {
         ...state,
-        activities: [...state.activities, action.payload.activity],
+        activities: [action.payload.activity, ...state.activities],
         activityCount: state.activityCount + 1,
       }
     case ACTIONS.DELETE_ACTIVITY: {
@@ -26,7 +29,7 @@ export const activityReducer = (state = initialState, action) => {
       return {
         ...state,
         activities: [...state.activitiesLog],
-        activityCount: state.activitiesLog.length,
+        activityCount: state.activityCount - 1,
       }
     }
     case ACTIONS.ERROR_ACTIVITY:

--- a/client/src/reducers/activityReducer.js
+++ b/client/src/reducers/activityReducer.js
@@ -6,11 +6,16 @@ const initialState = {
 export const activityReducer = (state = initialState, action) => {
   switch (action.type) {
     case ACTIONS.GET_ACTIVITIES:
-      return { ...state, activities: action.payload.activities }
+      return {
+        ...state,
+        activities: [...state.activities, ...action.payload.activities],
+        activityCount: action.payload.activityCount,
+      }
     case ACTIONS.ADD_ACTIVITY:
       return {
         ...state,
         activities: [...state.activities, action.payload.activity],
+        activityCount: state.activityCount + 1,
       }
     case ACTIONS.DELETE_ACTIVITY: {
       const activitiesLog = state.activities
@@ -18,7 +23,11 @@ export const activityReducer = (state = initialState, action) => {
         (activity) => activity._id === action.payload.activity._id,
       )
       activitiesLog.splice(index, 1)
-      return { ...state, activities: [...state.activitiesLog] }
+      return {
+        ...state,
+        activities: [...state.activitiesLog],
+        activityCount: state.activitiesLog.length,
+      }
     }
     case ACTIONS.ERROR_ACTIVITY:
       return { ...state, activityError: action.payload.error }

--- a/client/src/reducers/activityReducer.js
+++ b/client/src/reducers/activityReducer.js
@@ -9,7 +9,7 @@ export const activityReducer = (state = initialState, action) => {
       return {
         ...state,
         activities: [
-          ...(action.payload.additional ? state.activities : []),
+          ...(action.payload.add ? state.activities : []),
           ...action.payload.activities,
         ],
         activityCount: action.payload.activityCount,

--- a/client/src/reducers/activityReducer.js
+++ b/client/src/reducers/activityReducer.js
@@ -12,13 +12,12 @@ export const activityReducer = (state = initialState, action) => {
           ...(action.payload.add ? state.activities : []),
           ...action.payload.activities,
         ],
-        activityCount: action.payload.activityCount,
+        hasMore: action.payload.hasMore,
       }
     case ACTIONS.ADD_ACTIVITY:
       return {
         ...state,
         activities: [action.payload.activity, ...state.activities],
-        activityCount: state.activityCount + 1,
       }
     case ACTIONS.DELETE_ACTIVITY: {
       const activitiesLog = state.activities
@@ -29,7 +28,6 @@ export const activityReducer = (state = initialState, action) => {
       return {
         ...state,
         activities: [...state.activitiesLog],
-        activityCount: state.activityCount - 1,
       }
     }
     case ACTIONS.ERROR_ACTIVITY:


### PR DESCRIPTION
**Description**
Adds a "Load more" button to the activity list. By default only the 10 newest activities are displayed in the side bar, older activities can be loaded with the new button.

**Fixes** #12

**Type of change**

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

**Checklist**
- [x] I have read the [Contribution Guidelines](https://github.com/ayushagg31/Trellis/blob/master/CONTRIBUTING.md)
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream module

**Expected Outcome**
![Peek 2020-10-22 14-50](https://user-images.githubusercontent.com/5517677/96874072-022afc00-1476-11eb-8923-062f03e3d4cd.gif)

**Additional Information**
I extended the activities API with last and limit query parameters. To ensure consistency when retrieving more activities (f.e. when someone else created a new activity while on the page) I use the id of the last activity visible, instead of just skipping 10 items.

The API also returns a new "X-Has-More" header flag, which indicates if more activities are available. I had "X-Total-Count" first, but I think this is a better indicator if there are really more activities to load. Additionally I can set that flag with loading limit + 1, instead of additionally executing `Activity.countDocuments({ boardId: _id })`.